### PR TITLE
fix: tsconfig include defaults to **/* when files not specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^5.1.3"
   },
   "scripts": {
-    "build": "rimraf dist && tsc src/index.ts --declaration --outDir dist --removeComments",
+    "build": "rimraf dist && tsc",
     "lint": "eslint src",
     "prepare": "npm run build",
     "preversion": "npm test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",
     "esModuleInterop": true,
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "removeComments": true,
+  },
+  "include": [
+    "src",
+  ]
 }


### PR DESCRIPTION
Typescript tsconfig defaults have changed; when `files` is not specified, `include` defaults to `**/*`.